### PR TITLE
Flask-Caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     version="0.4",
     packages=["gdash"],
     include_package_data=True,
-    install_requires=['argparse', 'flask', 'Flask-Cache'],
+    install_requires=['argparse', 'flask', 'Flask-Caching'],
     entry_points={
         "console_scripts": [
             "gdash = gdash.app:main",


### PR DESCRIPTION
I am getting an exception while installing gdash on Centos 7. The recommendation now is to use Flask-Caching instead of Flask-Cache - https://github.com/thadeusb/flask-cache/issues/171. Please review and let me know if this is something we can change .. 

Thanks,
Ahsan